### PR TITLE
01/08 백엔드 이슈#31 해결

### DIFF
--- a/src/database/migrations/1768914412532-AddPostSelfReferencing.ts
+++ b/src/database/migrations/1768914412532-AddPostSelfReferencing.ts
@@ -1,0 +1,77 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddPostSelfReferencing1768914412532 implements MigrationInterface {
+  name = 'AddPostSelfReferencing1768914412532';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 1. Make categoryId nullable (for thread posts that inherit from parent)
+    await queryRunner.query(
+      `ALTER TABLE \`post\` MODIFY \`categoryId\` int NULL`,
+    );
+
+    // 2. Add parentPostId column (nullable, for self-referencing)
+    await queryRunner.query(
+      `ALTER TABLE \`post\` ADD \`parentPostId\` int NULL`,
+    );
+
+    // 3. Add foreign key constraint for self-referencing with CASCADE delete
+    // When a parent post is deleted, all its children (thread replies) are also deleted
+    await queryRunner.query(
+      `ALTER TABLE \`post\` ADD CONSTRAINT \`FK_post_parentPostId\`
+       FOREIGN KEY (\`parentPostId\`) REFERENCES \`post\`(\`id\`)
+       ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+
+    // 4. Add index for performance (querying child posts by parent)
+    await queryRunner.query(
+      `CREATE INDEX \`IDX_post_parentPostId\` ON \`post\` (\`parentPostId\`)`,
+    );
+
+    // 5. Add index for categoryId if it doesn't exist (performance optimization)
+    await queryRunner.query(
+      `CREATE INDEX \`IDX_post_categoryId\` ON \`post\` (\`categoryId\`)`,
+    );
+
+    // 6. Add check constraint to ensure business rules
+    // Either parentPostId is NULL and categoryId is NOT NULL (standalone post)
+    // OR parentPostId is NOT NULL (thread post, category can be inherited)
+    // Note: MySQL 8.0.16+ supports CHECK constraints
+    await queryRunner.query(
+      `ALTER TABLE \`post\` ADD CONSTRAINT \`CHK_post_parent_or_category\`
+       CHECK (
+         (\`parentPostId\` IS NULL AND \`categoryId\` IS NOT NULL) OR
+         (\`parentPostId\` IS NOT NULL)
+       )`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Reverse order of up() operations
+
+    // 6. Drop check constraint
+    await queryRunner.query(
+      `ALTER TABLE \`post\` DROP CHECK \`CHK_post_parent_or_category\``,
+    );
+
+    // 5. Drop categoryId index
+    await queryRunner.query(`DROP INDEX \`IDX_post_categoryId\` ON \`post\``);
+
+    // 4. Drop parentPostId index
+    await queryRunner.query(
+      `DROP INDEX \`IDX_post_parentPostId\` ON \`post\``,
+    );
+
+    // 3. Drop foreign key constraint
+    await queryRunner.query(
+      `ALTER TABLE \`post\` DROP FOREIGN KEY \`FK_post_parentPostId\``,
+    );
+
+    // 2. Drop parentPostId column
+    await queryRunner.query(`ALTER TABLE \`post\` DROP COLUMN \`parentPostId\``);
+
+    // 1. Restore categoryId to NOT NULL
+    await queryRunner.query(
+      `ALTER TABLE \`post\` MODIFY \`categoryId\` int NOT NULL`,
+    );
+  }
+}

--- a/src/posts/dto/create-post.dto.ts
+++ b/src/posts/dto/create-post.dto.ts
@@ -1,16 +1,40 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsNumber, ValidateIf } from 'class-validator';
 
 export class CreatePostDto {
-  @ApiProperty()
-  @IsNotEmpty()
-  categoryId: number;
+  @ApiProperty({
+    required: false,
+    description: '카테고리 ID (독립 게시글인 경우 필수, 쓰레드인 경우 선택)',
+    example: 1,
+  })
+  @IsOptional()
+  @IsNumber()
+  @ValidateIf((o) => !o.parentPostId)
+  @IsNotEmpty({ message: 'categoryId 또는 parentPostId 중 하나는 필수입니다.' })
+  categoryId?: number;
 
-  @ApiProperty()
+  @ApiProperty({
+    required: false,
+    description: '부모 게시글 ID (쓰레드/답글인 경우 필수)',
+    example: 5,
+  })
+  @IsOptional()
+  @IsNumber()
+  @ValidateIf((o) => !o.categoryId)
+  @IsNotEmpty({ message: 'categoryId 또는 parentPostId 중 하나는 필수입니다.' })
+  parentPostId?: number;
+
+  @ApiProperty({
+    description: '게시글 제목',
+    example: 'Docker 컨테이너 질문있습니다',
+  })
   @IsNotEmpty()
   title: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: '게시글 내용',
+    example: '컨테이너 실행 중 오류가 발생했는데...',
+  })
   @IsNotEmpty()
   content: string;
 }

--- a/src/posts/dto/get-post-filter.dto.ts
+++ b/src/posts/dto/get-post-filter.dto.ts
@@ -10,6 +10,11 @@ export class GetPostsFilterDto {
   @IsOptional()
   @Type(() => Number)
   @IsInt()
+  parentPostId?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
   @Min(1)
   page?: number = 1;
 

--- a/src/posts/entities/post.entity.ts
+++ b/src/posts/entities/post.entity.ts
@@ -31,11 +31,26 @@ export class Post {
 
   @ManyToOne(() => Category, (category) => category.posts, { nullable: true })
   @JoinColumn({ name: 'categoryId' })
-  category: Category;
+  category: Category | null;
 
   @Exclude()
   @RelationId((post: Post) => post.category)
-  categoryId: number;
+  categoryId: number | null;
+
+  // Self-referencing for thread/reply structure
+  @ManyToOne(() => Post, (post: Post) => post.childrenPosts, {
+    nullable: true,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'parentPostId' })
+  parentPost: Post | null;
+
+  @Exclude()
+  @RelationId((post: Post) => post.parentPost)
+  parentPostId: number | null;
+
+  @OneToMany(() => Post, (post: Post) => post.parentPost)
+  childrenPosts: Post[];
 
   @Column({ length: 255 })
   title: string;

--- a/src/posts/type/post-detail-response.dto.ts
+++ b/src/posts/type/post-detail-response.dto.ts
@@ -1,26 +1,39 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Expose, Type } from 'class-transformer';
 
-export class CommentDetailDto {
-  @ApiProperty({ example: 1 })
+// Flat comment structure with depth (Issue #31-4)
+export class CommentFlatDto {
+  @ApiProperty({ example: 1, description: '댓글 ID' })
   @Expose()
   id: number;
+
+  @ApiProperty({ example: null, required: false, description: '부모 댓글 ID' })
+  @Expose()
+  parentId: number | null;
+
+  @ApiProperty({ example: 0, description: '댓글 깊이 (0: 최상위, 1: 대댓글, ...)' })
+  @Expose()
+  depth: number;
+
+  @ApiProperty({ example: '작성자', description: '작성자 닉네임' })
+  @Expose()
+  author: string;
 
   @ApiProperty({ example: '댓글 내용' })
   @Expose()
   content: string;
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ example: 5, description: '좋아요 개수' })
   @Expose()
-  childrenCount: number;
+  likeCount: number;
 
-  @ApiProperty({
-    type: () => [CommentDetailDto],
-    description: '대댓글 목록',
-  })
+  @ApiProperty({ example: '2024-01-01T00:00:00.000Z' })
   @Expose()
-  @Type(() => CommentDetailDto)
-  children: CommentDetailDto[];
+  createdAt: Date;
+
+  @ApiProperty({ example: '2024-01-01T00:00:00.000Z' })
+  @Expose()
+  updatedAt: Date;
 }
 
 export class PostDetailResponseDto {
@@ -40,6 +53,30 @@ export class PostDetailResponseDto {
   @Expose()
   content: string;
 
+  @ApiProperty({ example: 1, required: false, description: '카테고리 ID' })
+  @Expose()
+  categoryId?: number | null;
+
+  @ApiProperty({
+    required: false,
+    description: '카테고리 정보',
+    example: { id: 1, name: 'Docker' },
+  })
+  @Expose()
+  category?: { id: number; name: string } | null;
+
+  @ApiProperty({ example: 1, required: false, description: '부모 게시글 ID' })
+  @Expose()
+  parentPostId?: number | null;
+
+  @ApiProperty({
+    required: false,
+    description: '부모 게시글 요약 정보',
+    example: { id: 5, title: '원본 게시글 제목', author: '작성자' },
+  })
+  @Expose()
+  parentPost?: { id: number; title: string; author: string } | null;
+
   // @ApiProperty({
   //   type: 'array',
   //   description: '좋아요 목록',
@@ -57,10 +94,30 @@ export class PostDetailResponseDto {
   commentsCount: number;
 
   @ApiProperty({
-    type: () => [CommentDetailDto],
-    description: '댓글 목록',
+    type: () => [CommentFlatDto],
+    description: '댓글 목록 (1차 배열, depth 포함)',
   })
   @Expose()
-  @Type(() => CommentDetailDto)
-  comments: CommentDetailDto[];
+  @Type(() => CommentFlatDto)
+  comments: CommentFlatDto[];
+
+  @ApiProperty({
+    required: false,
+    description: '답글(쓰레드) 게시글 목록',
+    example: [
+      {
+        id: 10,
+        title: '답글 제목',
+        author: '답글 작성자',
+        createdAt: '2024-01-01T00:00:00.000Z',
+      },
+    ],
+  })
+  @Expose()
+  childrenPosts?: Array<{
+    id: number;
+    title: string;
+    author: string;
+    createdAt: Date;
+  }>;
 }

--- a/src/posts/type/post-response.dto.ts
+++ b/src/posts/type/post-response.dto.ts
@@ -27,6 +27,14 @@ export class PostGetResponseData {
   @Expose()
   categoryId: number;
 
+  @ApiProperty({ example: 1, required: false, description: '부모 게시글 ID (쓰레드인 경우)' })
+  @Expose()
+  parentPostId?: number | null;
+
+  @ApiProperty({ example: 5, required: false, description: '답글(자식 게시글) 개수' })
+  @Expose()
+  childrenCount?: number;
+
   @ApiProperty({ example: 'title' })
   @Expose()
   title: string;


### PR DESCRIPTION
이슈 number 31에 요구사항에 대한 리팩토링 계획 및 백엔드 구조 변경
- 아래 플랜.md를 참조하세요
- Front Dev는 변경 사항에 대해 읽어보시고 스웨거를 참고해주세요.

# Post 자체 참조 구조 개선 플랜

## 개요

Post 엔티티에 자체 참조(self-referencing) 기능을 추가하여 쓰레드/댓글 구조를 지원하고, 공지사항 등 독립 게시글이 최상위 카테고리를 사용할 수 있도록 개선합니다. 이를 통해 GitHub 이슈 #31-2번(최상위 카테고리 게시글 생성 시 500 에러)을 해결합니다.

## 설계 방향: Separate Foreign Keys 방식

### 선택 근거
- TypeORM 네이티브 relation 활용 (Comment 엔티티와 동일한 패턴)
- FK 제약 조건으로 데이터 무결성 보장
- 타입 안전성 및 IDE 자동완성 지원
- 기존 코드베이스의 검증된 패턴 재사용
- **하위 호환성 불필요**: 프론트엔드 팀이 변경사항을 확인하고 동시에 수정

### 핵심 변경사항
```
Post 엔티티에 추가:
- parentPostId: number | null (새 컬럼)
- parentPost: Post | null (ManyToOne relation)
- childrenPosts: Post[] (OneToMany relation)

기존 필드 수정:
- categoryId: number → number | null (nullable로 변경)
```

### API 변경사항 (Breaking Changes)
**프론트엔드 팀 공유 필수**:
1. CreatePostDto: `categoryId` 이제 optional, `parentPostId` 추가
2. Response: `parentPostId`, `parentPost`, `childrenPosts` 필드 추가
3. GET /posts: `parentPostId` 쿼리 파라미터 추가 가능

## 주요 구현 내용

### 1. 데이터베이스 마이그레이션
**파일**: `backend/src/database/migrations/[timestamp]-AddPostSelfReferencing.ts`

- `parentPostId` 컬럼 추가 (nullable, FK with CASCADE)
- `categoryId`를 nullable로 변경
- CHECK 제약 조건: `parentPostId`가 null이면 `categoryId` 필수
- 인덱스 추가: `parentPostId`, `categoryId`

### 2. Post 엔티티 수정
**파일**: `backend/src/posts/entities/post.entity.ts`

```typescript
// 추가
@ManyToOne(() => Post, (post: Post) => post.childrenPosts, {
  nullable: true, onDelete: 'CASCADE'
})
parentPost: Post | null;

@RelationId((post: Post) => post.parentPost)
parentPostId: number | null;

@OneToMany(() => Post, (post: Post) => post.parentPost)
childrenPosts: Post[];

// 수정
categoryId: number | null; // 기존 number에서 nullable로
```

### 3. DTO 수정
**파일**: `backend/src/posts/dto/create-post.dto.ts`

```typescript
export class CreatePostDto {
  @IsOptional()
  @ValidateIf((o) => !o.parentPostId)
  categoryId?: number;

  @IsOptional()
  @ValidateIf((o) => !o.categoryId)
  parentPostId?: number;

  @IsNotEmpty()
  title: string;

  @IsNotEmpty()
  content: string;
}
```

**검증 규칙**: `categoryId`와 `parentPostId` 중 최소 하나는 필수

### 4. PostService 로직 개선
**파일**: `backend/src/posts/post.service.ts`

#### create() 메서드
```typescript
주요 로직:
1. parentPostId 제공 시:
   - 부모 Post 존재 여부 확인
   - categoryId 미제공 시 부모의 category 상속

2. categoryId 제공 시:
   - Category 존재 여부 확인
   - ✅ 최상위 카테고리 허용 (Issue #31-2 해결)

3. 최종 검증:
   - category가 반드시 설정되어야 함 (상속 또는 명시)
```

#### get() 메서드
```typescript
개선사항:
- parentPostId 필터 추가 (특정 Post의 쓰레드 조회)
- childrenCount 자동 로드 (답글 개수)
- parentPost relation 조인
```

#### findOne() 메서드
```typescript
개선사항:
- parentPost 정보 로드 (쓰레드의 원글 정보)
- childrenPosts 로드 (답글 목록)
- Response에 부모/자식 정보 포함
```

### 5. Response DTO 확장
**파일**: `backend/src/posts/type/post-response.dto.ts`, `post-detail-response.dto.ts`

```typescript
추가 필드:
- parentPostId?: number | null
- parentPost?: { id, title, author } | null
- childrenCount?: number
- childrenPosts?: PostDetailResponseDto[]
```

## 게시글 타입별 동작 방식

| 타입 | parentPostId | categoryId | category 출처 | 예시 |
|------|-------------|-----------|-------------|------|
| MD 문서 Post | null | 필수 | Seed 폴더 구조 | "1.1-컨테이너..." |
| 독립 Post | null | 필수 | 유저 선택 | "공지사항 글" |
| 쓰레드 Post (상속) | 필수 | 생략 가능 | 부모에서 상속 | "질문 답변" |
| 쓰레드 Post (명시) | 필수 | 명시 | 유저 선택 | "카테고리 변경한 답글" |

## Issue #31-2 해결 방안

**문제**: 최상위 카테고리(Docker 등)로 Post 생성 시 500 에러

**해결**:
1. PostService.create()에서 최상위 카테고리 제한 제거
2. 모든 계층의 카테고리 허용 (root, 중간, leaf 모두)
3. 명시적 검증 로직 추가

```typescript
// 기존: 암묵적으로 leaf category만 허용 (추정)
// 개선: 모든 카테고리 레벨 명시적 허용
if (categoryId) {
  category = await this.categoryRepository.findOne({
    where: { id: categoryId },
    relations: ['parent'],
  });

  if (!category) {
    throw new NotFoundException('존재하지 않는 카테고리입니다.');
  }

  // ✅ 최상위 카테고리 허용
  // category.parent가 null이어도 정상 처리
}
```

## 구현 단계 (안전한 배포)

### Phase 1: 데이터베이스 및 엔티티 (Day 1)
1. TypeORM 마이그레이션 파일 생성
2. 마이그레이션 실행 (Dev 환경)
3. Post 엔티티 수정
4. 기존 데이터 영향 없음 확인

### Phase 2: DTO 및 검증 (Day 2)
5. CreatePostDto 수정 (parentPostId 추가, categoryId optional)
6. Response DTO 확장 (parentPostId, parentPost, childrenPosts 추가)
7. **프론트엔드 팀에 API 변경사항 전달**

### Phase 3: 서비스 로직 (Day 3)
8. PostService.create() 개선 (Issue #31-2 수정 포함)
9. PostService.get() 개선 (parentPostId 필터 추가)
10. PostService.findOne() 개선 (parent/children 정보 추가)
11. GetPostsFilterDto에 parentPostId 필드 추가

### Phase 4: 테스트 (Day 4)
11. 단위 테스트 작성
    - 독립 Post 생성 (기존 동작)
    - 최상위 카테고리 Post 생성 (Issue #31-2)
    - 쓰레드 Post 생성 (새 기능)
    - 카테고리 상속 로직
    - CASCADE 삭제
12. 통합 테스트 (e2e)

### Phase 5: 배포 (Day 5-6)
13. Swagger API 문서 업데이트
14. Staging 배포 및 검증
15. Production 배포 (마이그레이션 → 앱)

## 롤백 전략

- **Phase 1-2**: `npm run typeorm:migration:revert`로 마이그레이션 되돌림
- **Phase 3-5**: 이전 버전 재배포 (DB 컬럼은 nullable이므로 무해)
- **중요**: 프론트엔드도 함께 롤백 필요 (API 변경사항 있음)

## 핵심 파일

1. `backend/src/posts/entities/post.entity.ts` - 엔티티 변경
2. `backend/src/posts/post.service.ts` - 비즈니스 로직
3. `backend/src/database/migrations/[timestamp]-AddPostSelfReferencing.ts` - 마이그레이션
4. `backend/src/posts/dto/create-post.dto.ts` - API 계약 (Breaking Change)
5. `backend/src/posts/dto/get-post-filter.dto.ts` - 필터 DTO (parentPostId 추가)
6. `backend/src/posts/type/post-response.dto.ts` - 응답 구조 (Breaking Change)
7. `backend/src/posts/type/post-detail-response.dto.ts` - 상세 응답 (Breaking Change)

## 검증 방법

### 수동 테스트 시나리오
```bash
# 1. 최상위 카테고리 Post 생성 (Issue #31-2 검증)
POST /posts
{ "categoryId": 1, "title": "공지", "content": "..." }
→ 200 OK 예상

# 2. 쓰레드 Post 생성 (새 기능)
POST /posts
{ "parentPostId": 5, "title": "답변", "content": "..." }
→ 200 OK, category 상속 확인

# 3. 쓰레드 조회
GET /posts?parentPostId=5
→ 답글 목록 반환

# 4. 상세 조회
GET /posts/10
→ parentPost, childrenPosts 정보 포함
```

### 데이터베이스 검증
```sql
-- 마이그레이션 후 확인
SHOW CREATE TABLE `post`;
-- parentPostId 컬럼, FK 제약, CHECK 제약 확인

-- 기존 데이터 확인
SELECT id, categoryId, parentPostId FROM `post` LIMIT 10;
-- 모든 기존 Post는 parentPostId = null이어야 함
```

## 프론트엔드 팀 공유사항

### API Breaking Changes 요약

#### 1. POST /posts (게시글 생성)
**변경 전**:
```json
{
  "categoryId": 1,  // 필수
  "title": "제목",
  "content": "내용"
}
```

**변경 후**:
```json
{
  "categoryId": 1,      // 선택 (독립 게시글인 경우 필수)
  "parentPostId": 5,    // 선택 (쓰레드인 경우 필수)
  "title": "제목",
  "content": "내용"
}
```
- 최소 하나는 필수: `categoryId` 또는 `parentPostId`
- 쓰레드 답글: `parentPostId`만 제공 (category 자동 상속)
- 독립 게시글: `categoryId`만 제공

#### 2. GET /posts (게시글 목록)
**새로운 쿼리 파라미터**:
```
GET /posts?parentPostId=5  # 특정 게시글의 답글(쓰레드) 조회
GET /posts?parentPostId=null  # 최상위 게시글만 조회
```

**응답 변경**:
```json
{
  "posts": [
    {
      "id": 1,
      "title": "...",
      "parentPostId": null,     // 신규
      "childrenCount": 5        // 신규: 답글 개수
    }
  ]
}
```

#### 3. GET /posts/:id (게시글 상세)
**응답 변경**:
```json
{
  "id": 1,
  "title": "...",
  "parentPostId": null,           // 신규
  "parentPost": {                 // 신규: 부모 게시글 정보
    "id": 5,
    "title": "원본 게시글",
    "author": "작성자"
  },
  "childrenPosts": [              // 신규: 답글 목록
    {
      "id": 10,
      "title": "답글1",
      "author": "답글 작성자",
      "createdAt": "2024-01-01"
    }
  ]
}
```

## 참고사항

- Comment 엔티티는 이미 동일한 self-referencing 패턴 사용 중
- 기존 seed 스크립트(`seed-up-from-folder.ts`)는 수정 불필요 (MD Post는 모두 parentPostId = null)
- **하위 호환성 없음**: 프론트엔드 동시 수정 필요

---

## Issue #31-5: 댓글 수정 기능 오류 해결 (2026-01-20)

### 문제점 분석

`backend/src/comments/comment.service.ts`의 create(), update(), remove() 메서드에서 다음 문제들 발견:

1. **에러 처리 문제**: catch 블록이 모든 에러를 500으로 반환하여 실제 에러(NotFoundException, UnauthorizedException 등)가 숨겨짐
2. **에러 메시지 오류**: "게시물 작성자" → "댓글 작성자"로 수정 필요
3. **응답 형식 불일치**: remove() 메서드만 `createApiResponse()` 대신 직접 객체 반환

### 수정 내용

**파일**: `backend/src/comments/comment.service.ts`

#### 1. Import 추가
```typescript
import {
  Injectable,
  InternalServerErrorException,  // 추가
  NotFoundException,
  UnauthorizedException,
} from '@nestjs/common';
```

#### 2. create() 메서드 개선
```typescript
// 변경 전: 모든 에러를 500으로 반환
catch (error) {
  console.error(error);
  return createApiResponse(500, '댓글 등록에 실패했습니다.');
}

// 변경 후: 특정 에러는 그대로 throw
catch (error) {
  console.error('Comment creation error:', error);

  // Preserve specific errors
  if (error instanceof NotFoundException) {
    throw error;
  }

  throw new InternalServerErrorException('댓글 등록에 실패했습니다.');
}
```

#### 3. update() 메서드 개선
```typescript
// 에러 메시지 수정 (line 122)
// 변경 전: '게시물 작성자만 수정할 수 있습니다.'
// 변경 후: '댓글 작성자만 수정할 수 있습니다.'

// 에러 처리 개선
catch (error) {
  console.error('Comment update error:', error);

  // Preserve specific errors
  if (
    error instanceof NotFoundException ||
    error instanceof UnauthorizedException
  ) {
    throw error;
  }

  throw new InternalServerErrorException('댓글 수정에 실패했습니다.');
}
```

#### 4. remove() 메서드 개선
```typescript
// 에러 메시지 수정 (line 154)
// 변경 전: '이미 삭제된 게시물입니다.'
// 변경 후: '이미 삭제된 댓글입니다.'

// 에러 메시지 수정 (line 157)
// 변경 전: '게시물 작성자만 삭제할 수 있습니다.'
// 변경 후: '댓글 작성자만 삭제할 수 있습니다.'

// 응답 형식 통일
// 변경 전: 직접 객체 반환
return {
  statusCode: 200,
  message: '댓글이 삭제되었습니다.',
};

// 변경 후: createApiResponse() 사용
return createApiResponse(200, '댓글이 삭제되었습니다.');

// 에러 처리 개선
catch (error) {
  console.error('Comment deletion error:', error);

  // Preserve specific errors
  if (
    error instanceof NotFoundException ||
    error instanceof UnauthorizedException
  ) {
    throw error;
  }

  throw new InternalServerErrorException('댓글 삭제에 실패했습니다.');
}
```

### 개선 효과

1. **정확한 HTTP 상태 코드**: 클라이언트가 에러 상황을 정확히 파악 가능
   - 댓글 없음: 404 Not Found
   - 권한 없음: 401 Unauthorized
   - 서버 오류: 500 Internal Server Error

2. **에러 메시지 정확성**: "게시물" → "댓글"로 수정하여 혼란 방지

3. **응답 형식 일관성**: 모든 메서드가 `createApiResponse()` 사용

4. **디버깅 용이성**: 구체적인 에러 로그 메시지로 문제 추적 용이

### 참고

- PostService의 에러 처리 패턴과 동일하게 적용
- NestJS Exception Filter가 throw된 에러를 자동으로 적절한 HTTP 응답으로 변환

---

## Issue #31-4: 댓글 구조 및 데이터 개선 (2026-01-20)

### 요구사항

GitHub Issue #31-4번에서 요청한 댓글 구조 개선:

1. **Depth 계산하여 1차 배열로 변환**: 계층 구조를 유지하면서 flat array로 제공
2. **추가 데이터 포함**:
   - `author` (작성자 닉네임)
   - `createdAt` (생성 시간)
   - `updatedAt` (수정 시간)
   - `likeCount` (좋아요 개수)
   - `depth` (댓글 깊이: 0=최상위, 1=대댓글, ...)
   - `parentId` (부모 댓글 ID)

### 설계 방향

**Breaking Change (하위 호환성 없음)**:
- 기존 계층 구조 `comments` 필드를 flat 구조로 대체
- `CommentDetailDto` 제거, `CommentFlatDto`로 통일
- 프론트엔드 동시 수정 필요

### 구현 내용

#### 1. DTO 변경

**파일**: `backend/src/posts/type/post-detail-response.dto.ts`

**제거**: `CommentDetailDto` (계층 구조)

**추가**: `CommentFlatDto` (Flat 구조)
```typescript
// Flat comment structure with depth (Issue #31-4)
export class CommentFlatDto {
  @ApiProperty({ example: 1, description: '댓글 ID' })
  @Expose()
  id: number;

  @ApiProperty({ example: null, required: false, description: '부모 댓글 ID' })
  @Expose()
  parentId: number | null;

  @ApiProperty({ example: 0, description: '댓글 깊이 (0: 최상위, 1: 대댓글, ...)' })
  @Expose()
  depth: number;

  @ApiProperty({ example: '작성자', description: '작성자 닉네임' })
  @Expose()
  author: string;

  @ApiProperty({ example: '댓글 내용' })
  @Expose()
  content: string;

  @ApiProperty({ example: 5, description: '좋아요 개수' })
  @Expose()
  likeCount: number;

  @ApiProperty({ example: '2024-01-01T00:00:00.000Z' })
  @Expose()
  createdAt: Date;

  @ApiProperty({ example: '2024-01-01T00:00:00.000Z' })
  @Expose()
  updatedAt: Date;
}
```

#### 2. PostDetailResponseDto 변경

```typescript
export class PostDetailResponseDto {
  // ... 기존 필드들 ...

  @ApiProperty({
    type: () => [CommentFlatDto],
    description: '댓글 목록 (1차 배열, depth 포함)',
  })
  @Expose()
  @Type(() => CommentFlatDto)
  comments: CommentFlatDto[];  // 계층 구조 제거, flat 구조로 대체

  // ... 나머지 필드들 ...
}
```

#### 3. PostService.findOne() 메서드 개선

**파일**: `backend/src/posts/post.service.ts`

**Relations 추가** (lines 211-212):
```typescript
relations: [
  'comments',
  'comments.children',
  'comments.likes',          // 댓글 좋아요 로드
  'comments.children.likes', // 대댓글 좋아요 로드
  // ... 기타 relations
]
```

**Flat 배열 변환 로직** (lines 225-258):
```typescript
const parentComments = post.comments.filter((comment) => !comment.parent);

// Flat comment structure with depth (Issue #31-4)
const comments: Array<{
  id: number;
  parentId: number | null;
  depth: number;
  author: string;
  content: string;
  likeCount: number;
  createdAt: Date;
  updatedAt: Date;
}> = [];

const flattenComments = (comment: Comment, depth: number = 0) => {
  comments.push({
    id: comment.id,
    parentId: comment.parent?.id ?? null,
    depth,
    author: comment.author,
    content: comment.content,
    likeCount: comment.likes?.length ?? 0,
    createdAt: comment.createdAt,
    updatedAt: comment.updatedAt,
  });

  // Recursively flatten children
  if (comment.children && comment.children.length > 0) {
    comment.children.forEach((child) => flattenComments(child, depth + 1));
  }
};

// Flatten all comments starting from parent comments
parentComments.forEach((comment) => flattenComments(comment));

const commentsCount = comments.length;  // 간소화
```

**응답 변경** (line 286):
```typescript
return createApiResponse(200, '단일 게시글 조회에 성공하였습니다.', {
  // ... 기존 필드들 ...
  commentsCount: commentsCount,
  comments,  // Flat structure only (Breaking Change)
  // ... 나머지 필드들 ...
});
```

**Import 정리**:
```typescript
// 제거: CommentDetailDto (더 이상 사용하지 않음)
import { PostDetailResponseDto } from './type/post-detail-response.dto';
```

### API 응답 예시

#### GET /posts/:id

**변경 전 (계층 구조)**:
```json
{
  "comments": [
    {
      "id": 1,
      "content": "부모 댓글",
      "childrenCount": 2,
      "children": [
        {
          "id": 2,
          "content": "대댓글 1",
          "childrenCount": 0,
          "children": []
        },
        {
          "id": 3,
          "content": "대댓글 2",
          "childrenCount": 0,
          "children": []
        }
      ]
    }
  ]
}
```

**변경 후 (Flat 구조 - Breaking Change)**:
```json
{
  "comments": [
    {
      "id": 1,
      "parentId": null,
      "depth": 0,
      "author": "작성자1",
      "content": "부모 댓글",
      "likeCount": 5,
      "createdAt": "2024-01-01T00:00:00.000Z",
      "updatedAt": "2024-01-01T00:00:00.000Z"
    },
    {
      "id": 2,
      "parentId": 1,
      "depth": 1,
      "author": "작성자2",
      "content": "대댓글 1",
      "likeCount": 2,
      "createdAt": "2024-01-01T01:00:00.000Z",
      "updatedAt": "2024-01-01T01:00:00.000Z"
    },
    {
      "id": 3,
      "parentId": 1,
      "depth": 1,
      "author": "작성자3",
      "content": "대댓글 2",
      "likeCount": 0,
      "createdAt": "2024-01-01T02:00:00.000Z",
      "updatedAt": "2024-01-01T02:00:00.000Z"
    }
  ]
}
```

### 개선 효과

1. **프론트엔드 효율성 증대**:
   - 댓글마다 별도 조회 불필요
   - 모든 필요한 데이터를 한 번에 제공
   - Flat 배열로 렌더링 로직 단순화

2. **완전한 정보 제공**:
   - 작성자 정보 (`author`)
   - 타임스탬프 (`createdAt`, `updatedAt`)
   - 좋아요 개수 (`likeCount`)
   - Depth 정보로 UI 들여쓰기 가능 (`depth`)
   - 부모 댓글 참조 (`parentId`)

3. **구조 단순화**:
   - 계층 구조를 순회할 필요 없이 단순 배열 반복
   - `depth` 기반으로 UI 렌더링
   - 댓글 트리 구조 재구성 불필요

4. **Breaking Change**:
   - 프론트엔드 동시 수정 필수
   - 기존 계층 구조 코드 변경 필요
   - `comments` 필드 구조 완전히 변경됨

### 주요 파일

1. `backend/src/posts/type/post-detail-response.dto.ts`
   - `CommentDetailDto` 제거 (계층 구조)
   - `CommentFlatDto` 추가 (Flat 구조)
   - `PostDetailResponseDto.comments` 타입 변경

2. `backend/src/posts/post.service.ts`
   - `CommentDetailDto` import 제거
   - findOne() 메서드 개선 (계층 구조 변환 로직 제거)
   - Flat 배열 생성 로직으로 대체

### 프론트엔드 팀 공유 필수

**Breaking Change Alert**:

GET `/posts/:id` 응답의 `comments` 필드 구조가 완전히 변경되었습니다.

**변경 전**:
- 계층 구조 (중첩된 `children` 배열)
- 필드: `id`, `content`, `childrenCount`, `children`

**변경 후**:
- Flat 배열 (1차원 배열)
- 필드: `id`, `parentId`, `depth`, `author`, `content`, `likeCount`, `createdAt`, `updatedAt`

**프론트엔드 수정 필요**:
1. `comments` 배열 순회 로직 변경
2. `depth` 기반 들여쓰기 렌더링
3. `parentId`로 답글 관계 파악
4. 작성자/타임스탬프 표시 추가

### 참고

- Comment 엔티티의 `likes`, `createdAt`, `updatedAt` 필드 활용
- 재귀 함수로 계층 구조를 flat array로 변환
- Depth-first 순회로 순서 보장
- `commentsCount` 계산 간소화 (`comments.length`)
